### PR TITLE
Fix `String.Format` to handle formatting of multiple types correctly, not only DateTime

### DIFF
--- a/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
+++ b/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
@@ -344,16 +344,22 @@ namespace HandlebarsDotNet.Helpers.Helpers
         }
 
         [HandlebarsWriter(WriterType.String)]
-        public string Format(object value, string format)
+        public string Format(object? value, string format)
         {
-            switch (value)
-            {
-                case DateTime dateTime:
-                    return dateTime.ToString(format, Context.Configuration.FormatProvider);
+            var formatProvider = Context.Configuration.FormatProvider;
 
-                default:
-                    throw new NotSupportedException($"The method {nameof(Format)} cannot be used on value '{value}' of Type '{value?.GetType()}'.");
-            }
+            // Attempt using a custom formatter from the format provider (if any)
+            var customFormatter = formatProvider?.GetFormat(typeof(ICustomFormatter)) as ICustomFormatter;
+            var formattedValue = customFormatter?.Format(format, value, formatProvider);
+
+            // Fallback to IFormattable
+            formattedValue ??= (value as IFormattable)?.ToString(format, formatProvider);
+
+            // Fallback to ToString
+            formattedValue ??= value?.ToString();
+
+            // Done
+            return formattedValue ?? "";
         }
 
         public StringHelpers(IHandlebars context) : base(context)

--- a/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
+++ b/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
@@ -359,7 +359,7 @@ namespace HandlebarsDotNet.Helpers.Helpers
             formattedValue ??= value?.ToString();
 
             // Done
-            return formattedValue ?? "";
+            return formattedValue ?? string.Empty;
         }
 
         public StringHelpers(IHandlebars context) : base(context)

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/StringHelpersTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/StringHelpersTests.cs
@@ -312,5 +312,46 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
             result1.Should().Be(expected);
             result2.Should().Be(expected);
         }
+        
+        [Theory]
+        [InlineData("N0", "1")]
+        [InlineData("N1", "1.2")]
+        [InlineData("N2", "1.20")]
+        public void Format_Decimal(string format, string expected)
+        {
+            // Arrange
+            var value = 1.2m;
+
+            // Act
+            var result1 = _sut.Format(value, format);
+            var result2 = _sut.Format((decimal?)value, format);
+
+            // Assert
+            result1.Should().Be(expected);
+            result2.Should().Be(expected);
+        }
+
+        [Fact]
+        public void Format_NotIFormattableType()
+        {
+            // Arrange
+            var value = new Version(1, 2, 3, 4);
+            
+            // Act
+            var result = _sut.Format(value, "should-be-ignored");
+
+            // Assert
+            result.Should().Be(value.ToString());
+        }
+
+        [Fact]
+        public void Format_Null()
+        {
+            // Act
+            var result = _sut.Format(null, "should-be-ignored");
+
+            // Assert
+            result.Should().BeEmpty();
+        }
     }
 }

--- a/test/Handlebars.Net.Helpers.Tests/Templates/StringHelpersTemplateTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Templates/StringHelpersTemplateTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using FluentAssertions;
 using HandlebarsDotNet.Helpers.Utils;
 using Moq;
@@ -21,6 +22,7 @@ namespace HandlebarsDotNet.Helpers.Tests.Templates
             _dateTimeServiceMock.Setup(d => d.UtcNow()).Returns(DateTimeNow.ToUniversalTime);
 
             _handlebarsContext = Handlebars.Create();
+            _handlebarsContext.Configuration.FormatProvider = CultureInfo.InvariantCulture;
 
             HandlebarsHelpers.Register(_handlebarsContext, o =>
             {


### PR DESCRIPTION
Hi,

First, thanks for the hard work and the great library !

I started using Handlebars.Net and the associated Handlebars.Net.Helpers because I need to format values (which Stubble can't do easily). What I need to format is an "Instant" value representing a date from the "NodaTime" library.

I was quite surprised to get an error `The method Format cannot be used on value '2001-11-21T00:00:00Z' of Type 'NodaTime.Instant'`.

Looking into the code, it seems that only DateTime is supported:
```csharp
[HandlebarsWriter(WriterType.String)]
public string Format(object value, string format)
{
    switch (value)
    {
        case DateTime dateTime:
            return dateTime.ToString(format, Context.Configuration.FormatProvider);

        default:
            throw new NotSupportedException($"The method {nameof(Format)} cannot be used on value '{value}' of Type '{value?.GetType()}'.");
    }
}
```

The method should make use of `ICustomFormatter` and `IFormattable` to format values as these interfaces are intended for this purpose (this is what the `String.Format` method uses to format string). Using these interfaces would allow formatting anything that can be like the `String.Format` method does.

Here is an example of a failing test that attempts to format a `Decimal` (But it is the same for NodaTime `Instant`):
```csharp
[Fact]
public void TestFormat()
{
    // Arrange
    var data = new { MyValue = 1.2m };
    var template = @"{{String.Format MyValue ""N2""}}";

    var x = data.MyValue.ToString("N2");
    
    // Act
    var compiledTemplate = _target.PublicGetCompiledTemplate(template);

    // Assert
    var rendered = compiledTemplate(data);
    rendered.Should().Be("1.20");
}
```