### PR TITLE
Fix the String.Join helper for IEnumerable

### DIFF
--- a/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
+++ b/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections;
 using System.Linq;
 using System.Text;
 using HandlebarsDotNet.Helpers.Attributes;
@@ -121,14 +121,14 @@ namespace HandlebarsDotNet.Helpers.Helpers
         }
 
         [HandlebarsWriter(WriterType.String)]
-        public string Join(IEnumerable<object> values, string? separator = null)
+        public string Join(IEnumerable values, string? separator = null)
         {
             if (values == null)
             {
                 throw new ArgumentNullException(nameof(values));
             }
 
-            return separator is null ? string.Join(string.Empty, values) : string.Join(separator, values);
+            return string.Join(separator ?? string.Empty, values.Cast<object>());
         }
 
         [HandlebarsWriter(WriterType.String)]

--- a/test/Handlebars.Net.Helpers.Tests/Templates/StringHelpersTemplateTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Templates/StringHelpersTemplateTests.cs
@@ -78,6 +78,21 @@ namespace HandlebarsDotNet.Helpers.Tests.Templates
         }
 
         [Theory]
+        [InlineData("{{String.Join numbers}}", "1234")]
+        [InlineData("{{String.Join numbers \", \"}}", "1, 2, 3, 4")]
+        public void JoinArray(string template, string expected)
+        {
+            // Arrange
+            var action = _handlebarsContext.Compile(template);
+
+            // Act
+            var result = action(new { numbers = new[] { 1, 2, 3, 4 } });
+
+            // Assert
+            result.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("{{[String.Split] \"a,b,c\" ','}}", "[\"a\",\"b\",\"c\"]")]
         [InlineData("{{[String.Split] \"a_;b_;c\" \"_;\"}}", "[\"a\",\"b\",\"c\"]")]
         public void Split(string template, string expected)


### PR DESCRIPTION
When passing an actual IEnumerable<T> (as opposed to a hardcoded list in a template) the following exception was thrown:
> **System.ArgumentException**: Object of type '[…]' cannot be converted to type 'System.Collections.Generic.IEnumerable`1[System.Object]'.

Changing the method signature to use IEnumerable instead of IEnumerable<object> fixes this issue.