### PR TITLE
PluginLoader does not require file system access

### DIFF
--- a/src/Handlebars.Net.Helpers/Plugin/PluginLoader.cs
+++ b/src/Handlebars.Net.Helpers/Plugin/PluginLoader.cs
@@ -13,22 +13,30 @@ namespace HandlebarsDotNet.Helpers.Plugin
         public static IDictionary<Category, IHelpers> Load(IEnumerable<string> paths, IDictionary<Category, string> items, params object[] args)
         {
             var pluginTypes = new List<Type>();
-            foreach (var file in paths.SelectMany(path => Directory.GetFiles(path, "*.dll")))
+            try
             {
-                try
+                foreach (var file in paths.SelectMany(path => Directory.GetFiles(path, "*.dll")))
                 {
-                    var assembly = Assembly.Load(new AssemblyName
+                    try
                     {
-                        Name = Path.GetFileNameWithoutExtension(file)
-                    });
+                        var assembly = Assembly.Load(new AssemblyName
+                        {
+                            Name = Path.GetFileNameWithoutExtension(file)
+                        });
 
-                    pluginTypes.AddRange(GetImplementationTypeByInterface(assembly));
-                }
-                catch
-                {
-                    // no-op: just try next .dll
+                        pluginTypes.AddRange(GetImplementationTypeByInterface(assembly));
+                    }
+                    catch
+                    {
+                        // no-op: just try next .dll
+                    }
                 }
             }
+            catch
+            {
+                // no-op: file system access possibly denied, don't search for files
+            }
+
 
             var helpers = new Dictionary<Category, IHelpers>();
             foreach (var item in items)


### PR DESCRIPTION
Added exception handler in PluginLoader in case host system does not have permission to read from the local file system.  This means that external plugins are not loaded but core internal functionality can still be used.  This is particularly useful when using Handlebars.Net.Helpers in a Xamarin Forms app (more specifically using WireMock in an app with Json configuration and Response Templates that rely on HandleBars.Net).