### PR TITLE
allow String equals checks to have null values

### DIFF
--- a/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
+++ b/src/Handlebars.Net.Helpers/Helpers/StringHelpers.cs
@@ -358,16 +358,12 @@ internal class StringHelpers : BaseHelpers, IHelpers
     [HandlebarsWriter(WriterType.Value)]
     public bool Equal(string value, string test)
     {
-        Guard.NotNull(value, nameof(value));
-
         return value == test;
     }
         
     [HandlebarsWriter(WriterType.Value)]
     public bool NotEqual(string value, string test)
     {
-        Guard.NotNull(value, nameof(value));
-
         return value != test;
     }
 

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/StringHelpersTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/StringHelpersTests.cs
@@ -360,6 +360,9 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
         [InlineData("foo", "Foo", false)]
         [InlineData("Foo", "foo", false)]
         [InlineData("foo", "foo", true)]
+        [InlineData(null, null, true)]
+        [InlineData(null, "foo", false)]
+        [InlineData("foo", null, false)]
         public void Equal(string value, string test, bool expected)
         {
             // Act
@@ -375,6 +378,9 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
         [InlineData("foo", "Foo", true)]
         [InlineData("Foo", "foo", true)]
         [InlineData("foo", "foo", false)]
+        [InlineData(null, null, false)]
+        [InlineData(null, "foo", true)]
+        [InlineData("foo", null, true)]
         public void NotEqual(string value, string test, bool expected)
         {
             // Act


### PR DESCRIPTION
null is a valid value for a string and therefore should be allowed in equality functions, especially when the string is coming from an unknown source where it might be null.