### PR TITLE
Fixed casting problems in ExecuteUtils breaking EnumerableHelpers

### DIFF
--- a/src/Handlebars.Net.Helpers/Helpers/EnumerableHelpers.cs
+++ b/src/Handlebars.Net.Helpers/Helpers/EnumerableHelpers.cs
@@ -14,7 +14,7 @@ namespace HandlebarsDotNet.Helpers.Helpers;
 internal class EnumerableHelpers : BaseHelpers, IHelpers
 {
     [HandlebarsWriter(WriterType.Value)]
-    public object Average(IEnumerable<object> values)
+    public double Average(IEnumerable<object> values)
     {
         return ExecuteUtils.Execute(values, x => x.Average());
     }
@@ -59,13 +59,13 @@ internal class EnumerableHelpers : BaseHelpers, IHelpers
     }
 
     [HandlebarsWriter(WriterType.Value)]
-    public object Max(IEnumerable<object> values)
+    public double Max(IEnumerable<object> values)
     {
         return ExecuteUtils.Execute(values, x => x.Max());
     }
 
     [HandlebarsWriter(WriterType.Value)]
-    public object Min(IEnumerable<object> values)
+    public double Min(IEnumerable<object> values)
     {
         return ExecuteUtils.Execute(values, x => x.Min());
     }
@@ -109,7 +109,7 @@ internal class EnumerableHelpers : BaseHelpers, IHelpers
     }
 
     [HandlebarsWriter(WriterType.Value)]
-    public object Sum(IEnumerable<object> values)
+    public double Sum(IEnumerable<object> values)
     {
         return ExecuteUtils.Execute(values, x => x.Sum());
     }

--- a/src/Handlebars.Net.Helpers/Utils/ExecuteUtils.cs
+++ b/src/Handlebars.Net.Helpers/Utils/ExecuteUtils.cs
@@ -37,7 +37,7 @@ public static class ExecuteUtils
                     return doubleFunc(valueParsedAsDouble);
                 }
 
-                throw new NotSupportedException($"The value '{valueAsString}' cannot not be converted to an int, long or double.");
+                throw new NotSupportedException($"The value '{valueAsString}' cannot be converted to an int, long or double.");
 
             default:
                 // Just call ToString()
@@ -74,7 +74,7 @@ public static class ExecuteUtils
                     return doubleFunc(valueParsedAsDouble);
                 }
 
-                throw new NotSupportedException($"The value '{valueAsString}' cannot not be converted to an int, long or double.");
+                throw new NotSupportedException($"The value '{valueAsString}' cannot be converted to an int, long or double.");
 
             default:
                 // Just call ToString()
@@ -129,7 +129,7 @@ public static class ExecuteUtils
         }
         catch
         {
-            throw new NotSupportedException($"The value '{value}' cannot not be converted to a double.");
+            throw new NotSupportedException($"The value '{value}' cannot be converted to a double.");
         }
     }
 
@@ -142,7 +142,7 @@ public static class ExecuteUtils
         }
         catch
         {
-            throw new NotSupportedException($"One of the values cannot not be converted to a double.");
+            throw new NotSupportedException($"One of the values cannot be converted to a double.");
         }
     }
 
@@ -156,7 +156,7 @@ public static class ExecuteUtils
         }
         catch
         {
-            throw new NotSupportedException($"The value '{value1}' or '{value2}' cannot not be converted to a double.");
+            throw new NotSupportedException($"The value '{value1}' or '{value2}' cannot be converted to a double.");
         }
     }
 }

--- a/src/Handlebars.Net.Helpers/Utils/ExecuteUtils.cs
+++ b/src/Handlebars.Net.Helpers/Utils/ExecuteUtils.cs
@@ -129,7 +129,7 @@ public static class ExecuteUtils
         }
         catch
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException($"The value '{value}' cannot not be converted to a double.");
         }
     }
 
@@ -137,11 +137,12 @@ public static class ExecuteUtils
     {
         try
         {
-            return doubleFunc(values.Cast<double>());
+            var doubles = values.Select(Convert.ToDouble);
+            return doubleFunc(doubles);
         }
         catch
         {
-            throw new NotSupportedException();
+            throw new NotSupportedException($"One of the values cannot not be converted to a double.");
         }
     }
 
@@ -155,7 +156,7 @@ public static class ExecuteUtils
         }
         catch
         {
-            throw new NotSupportedException($"The value '{value1}' cannot not be converted to a double.");
+            throw new NotSupportedException($"The value '{value1}' or '{value2}' cannot not be converted to a double.");
         }
     }
 }

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/EnumerableHelpersTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/EnumerableHelpersTests.cs
@@ -184,7 +184,7 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
             var result = _sut.Sum(array);
 
             // Assert
-            result.Should().Be(450.6);
+            result.Should().BeApproximately(450.6, 0.0001);
         }
 
         [Fact]

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/EnumerableHelpersTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/EnumerableHelpersTests.cs
@@ -147,5 +147,70 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
             result.Should().HaveCount(2);
             result.Should().BeEquivalentTo(9, null);
         }
+
+        [Fact]
+        public void Sum_double_Property_From_Array()
+        {
+            // Arrange
+            var array = new object[] { 10.0, 20.0, 30.0 };
+
+            // Act
+            var result = _sut.Sum(array);
+
+            // Assert
+            result.Should().Be(60.0);
+        }
+
+        [Fact]
+        public void Sum_int_Property_From_Array()
+        {
+            // Arrange
+            var array = new object[]{ 10, 20, 30 };
+
+            // Act
+            var result = _sut.Sum(array);
+
+            // Assert
+            result.Should().Be(60);
+        }
+
+        [Fact]
+        public void Min_Property_From_Array()
+        {
+            // Arrange
+            var array = new object[] { 10.0, 20.0, 30.0 };
+
+            // Act
+            var result = _sut.Min(array);
+
+            // Assert
+            result.Should().Be(10.0);
+        }
+
+        [Fact]
+        public void Max_Property_From_Array()
+        {
+            // Arrange
+            var array = new object[] { 10.0, 20.0, 30.0 };
+
+            // Act
+            var result = _sut.Max(array);
+
+            // Assert
+            result.Should().Be(30.0);
+        }
+
+        [Fact]
+        public void Average_Property_From_Array()
+        {
+            // Arrange
+            var array = new object[] { 10.0, 20.0, 30.0 };
+
+            // Act
+            var result = _sut.Average(array);
+
+            // Assert
+            result.Should().Be(20.0);
+        }
     }
 }

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/EnumerableHelpersTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/EnumerableHelpersTests.cs
@@ -175,6 +175,19 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
         }
 
         [Fact]
+        public void Sum_mixed_Properties_From_Array()
+        {
+            // Arrange
+            var array = new object[]{ 10, 20.1f, 30.2d, 40L, 50UL, (short)60, (ushort)70, 80.3m, 90U };
+
+            // Act
+            var result = _sut.Sum(array);
+
+            // Assert
+            result.Should().Be(450.6);
+        }
+
+        [Fact]
         public void Min_Property_From_Array()
         {
             // Arrange

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/ExecuteUtilsTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/ExecuteUtilsTests.cs
@@ -1,0 +1,52 @@
+﻿using FluentAssertions;
+using HandlebarsDotNet.Helpers.Utils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+
+namespace HandlebarsDotNet.Helpers.Tests.Helpers
+{
+    public class ExecuteUtilsTests
+    {
+        [Fact]
+        public void Execute_function_with_invalid_data_should_throw_exception()
+        {
+            // Arrange
+            var value = "invalid data";
+
+            // Act and Assert 
+            value
+                .Invoking(v => ExecuteUtils.Execute(v, Math.Sqrt))
+                .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Execute_array_function_with_invalid_data_should_throw_exception()
+        {
+            // Arrange
+            var array = new object[] { "invalid data" };
+            var function = new Func<IEnumerable<double> , double>(x => x.FirstOrDefault());
+
+            // Act and Assert 
+            array
+                .Invoking(v => ExecuteUtils.Execute(v, function))
+                .Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void Execute_two_argument_function_with_invalid_data_should_throw_exception()
+        {
+            // Arrange
+            var v1 = 10.0;
+            var v2 = "invalid data";
+            var function = new Func<double, double, double>((x, y) => x + y);
+
+            // Act and Assert 
+            v1
+                .Invoking(v => ExecuteUtils.Execute(null!, v, v2, function))
+                .Should().Throw<NotSupportedException>();
+        }
+    }
+}

--- a/test/Handlebars.Net.Helpers.Tests/Helpers/ExecuteUtilsTests.cs
+++ b/test/Handlebars.Net.Helpers.Tests/Helpers/ExecuteUtilsTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-
 namespace HandlebarsDotNet.Helpers.Tests.Helpers
 {
     public class ExecuteUtilsTests
@@ -27,7 +26,7 @@ namespace HandlebarsDotNet.Helpers.Tests.Helpers
         {
             // Arrange
             var array = new object[] { "invalid data" };
-            var function = new Func<IEnumerable<double> , double>(x => x.FirstOrDefault());
+            var function = new Func<IEnumerable<double>, double>(x => x.FirstOrDefault());
 
             // Act and Assert 
             array


### PR DESCRIPTION
- Average, Min, Max and Sum functions in EnumerableHelpers was broken due to casting bug in ExecuteUtils
- Improved error messages
- Added Tests using these methods